### PR TITLE
Reduce release binary sizes with minify and UPX compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,13 @@ jobs:
           bun build ./src/index.ts --compile --minify --target=bun-darwin-arm64 --outfile linproj-Darwin-arm64
           bun build ./src/index.ts --compile --minify --target=bun-linux-x64 --outfile linproj-Linux-x86_64
           bun build ./src/index.ts --compile --minify --target=bun-linux-arm64 --outfile linproj-Linux-aarch64
-      - name: Compress Linux binaries with UPX
+      - name: Compress binaries with UPX
         run: |
-          # UPX doesn't support macOS binaries (--force-macos produces non-functional executables)
           upx -9 linproj-Linux-x86_64
           upx -9 linproj-Linux-aarch64
+          # macOS UPX binary for debugging (--force-macos produces non-functional executables)
+          cp linproj-Darwin-arm64 linproj-Darwin-arm64-upx
+          upx -9 --force-macos linproj-Darwin-arm64-upx
       - name: Extract changelog for version
         id: changelog
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-01-24
+
+### Changed
+
+- Reduced release binary sizes with minify and UPX compression
+- Added experimental UPX-compressed macOS binary (`linproj-Darwin-arm64-upx`) for debugging
+
 ## [0.3.0] - 2025-01-24
 
 ### Added
@@ -49,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `issues create` command with team selection, priority, and assignment
 - API key authentication
 
+[0.3.1]: https://github.com/downstairs-dawgs/linproj/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/downstairs-dawgs/linproj/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/downstairs-dawgs/linproj/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/downstairs-dawgs/linproj/compare/v0.1.0...v0.1.1


### PR DESCRIPTION
## Summary
- Add `--minify` flag to all `bun build` commands in release workflow
- Add UPX compression step to compress binaries after build

This should reduce binary sizes from 50-90MB down to ~15-30MB.

## Test plan
- [ ] Create a test release tag and verify binaries are compressed
- [ ] Download and run compressed binaries on macOS and Linux to verify they work

🤖 Generated with [Claude Code](https://claude.com/claude-code)