### PR TITLE
Add quick commands: issues done and issues start

### DIFF
--- a/src/commands/issues/done.ts
+++ b/src/commands/issues/done.ts
@@ -1,0 +1,102 @@
+import { Command } from 'commander';
+import { getAuthContext } from '../../lib/config.ts';
+import {
+  LinearClient,
+  getIssue,
+  updateIssue,
+  getWorkflowStates,
+  type Issue,
+} from '../../lib/api.ts';
+import { resolveTeam } from '../../lib/resolve.ts';
+
+export interface DoneOptions {
+  json?: boolean;
+  quiet?: boolean;
+  workspace?: string;
+}
+
+async function getCompletedStateId(
+  client: LinearClient,
+  teamId: string
+): Promise<string> {
+  const states = await getWorkflowStates(client, teamId);
+  const completedState = states.find((s) => s.type === 'completed');
+  if (!completedState) {
+    throw new Error('No completed state found for this team');
+  }
+  return completedState.id;
+}
+
+function printResult(issue: Issue, previousState: string): void {
+  console.log(`✓ ${issue.identifier} → ${issue.state.name} (was: ${previousState})`);
+  console.log();
+  console.log(issue.url);
+}
+
+export function createDoneCommand(): Command {
+  return new Command('done')
+    .description('Mark an issue as done')
+    .argument('<identifier>', 'Issue identifier (e.g., PROJ-123)')
+    .option('--json', 'Output as JSON')
+    .option('--quiet', 'Suppress output on success')
+    .option('-w, --workspace <name>', 'Use a different workspace')
+    .action(async (identifier: string, options: DoneOptions) => {
+      let ctx;
+      try {
+        ctx = await getAuthContext(options.workspace);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      const client = new LinearClient(ctx.auth);
+
+      const issue = await getIssue(client, identifier);
+      if (!issue) {
+        console.error(`Error: Issue '${identifier}' not found`);
+        process.exit(1);
+      }
+
+      if (!issue.team?.key) {
+        console.error('Error: Issue has no team');
+        process.exit(1);
+      }
+
+      // Check if already completed
+      if (issue.state.type === 'completed') {
+        if (!options.quiet) {
+          console.log(`Issue ${identifier} is already done (${issue.state.name})`);
+        }
+        return;
+      }
+
+      const previousState = issue.state.name;
+      const teamId = await resolveTeam(client, issue.team.key);
+      const stateId = await getCompletedStateId(client, teamId);
+
+      const updated = await updateIssue(client, issue.id, { stateId });
+
+      if (options.quiet) {
+        return;
+      }
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              success: true,
+              issue: updated,
+              changes: {
+                state: { from: previousState, to: updated.state.name },
+              },
+            },
+            null,
+            2
+          )
+        );
+        return;
+      }
+
+      printResult(updated, previousState);
+    });
+}

--- a/src/commands/issues/index.ts
+++ b/src/commands/issues/index.ts
@@ -4,6 +4,8 @@ import { createCreateCommand } from './create.ts';
 import { createGetCommand } from './get.ts';
 import { createSearchCommand } from './search.ts';
 import { createEditCommand } from './edit.ts';
+import { createDoneCommand } from './done.ts';
+import { createStartCommand } from './start.ts';
 
 export function createIssuesCommand(): Command {
   const issues = new Command('issues').description('Issue commands');
@@ -13,6 +15,8 @@ export function createIssuesCommand(): Command {
   issues.addCommand(createGetCommand());
   issues.addCommand(createSearchCommand());
   issues.addCommand(createEditCommand());
+  issues.addCommand(createDoneCommand());
+  issues.addCommand(createStartCommand());
 
   return issues;
 }

--- a/src/commands/issues/start.ts
+++ b/src/commands/issues/start.ts
@@ -1,0 +1,102 @@
+import { Command } from 'commander';
+import { getAuthContext } from '../../lib/config.ts';
+import {
+  LinearClient,
+  getIssue,
+  updateIssue,
+  getWorkflowStates,
+  type Issue,
+} from '../../lib/api.ts';
+import { resolveTeam } from '../../lib/resolve.ts';
+
+export interface StartOptions {
+  json?: boolean;
+  quiet?: boolean;
+  workspace?: string;
+}
+
+async function getStartedStateId(
+  client: LinearClient,
+  teamId: string
+): Promise<string> {
+  const states = await getWorkflowStates(client, teamId);
+  const startedState = states.find((s) => s.type === 'started');
+  if (!startedState) {
+    throw new Error('No started state found for this team');
+  }
+  return startedState.id;
+}
+
+function printResult(issue: Issue, previousState: string): void {
+  console.log(`✓ ${issue.identifier} → ${issue.state.name} (was: ${previousState})`);
+  console.log();
+  console.log(issue.url);
+}
+
+export function createStartCommand(): Command {
+  return new Command('start')
+    .description('Start working on an issue')
+    .argument('<identifier>', 'Issue identifier (e.g., PROJ-123)')
+    .option('--json', 'Output as JSON')
+    .option('--quiet', 'Suppress output on success')
+    .option('-w, --workspace <name>', 'Use a different workspace')
+    .action(async (identifier: string, options: StartOptions) => {
+      let ctx;
+      try {
+        ctx = await getAuthContext(options.workspace);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      const client = new LinearClient(ctx.auth);
+
+      const issue = await getIssue(client, identifier);
+      if (!issue) {
+        console.error(`Error: Issue '${identifier}' not found`);
+        process.exit(1);
+      }
+
+      if (!issue.team?.key) {
+        console.error('Error: Issue has no team');
+        process.exit(1);
+      }
+
+      // Check if already started
+      if (issue.state.type === 'started') {
+        if (!options.quiet) {
+          console.log(`Issue ${identifier} is already in progress (${issue.state.name})`);
+        }
+        return;
+      }
+
+      const previousState = issue.state.name;
+      const teamId = await resolveTeam(client, issue.team.key);
+      const stateId = await getStartedStateId(client, teamId);
+
+      const updated = await updateIssue(client, issue.id, { stateId });
+
+      if (options.quiet) {
+        return;
+      }
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            {
+              success: true,
+              issue: updated,
+              changes: {
+                state: { from: previousState, to: updated.state.name },
+              },
+            },
+            null,
+            2
+          )
+        );
+        return;
+      }
+
+      printResult(updated, previousState);
+    });
+}

--- a/tests/e2e/issues-done.test.ts
+++ b/tests/e2e/issues-done.test.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E tests for issues done command.
+ *
+ * Requires valid Linear authentication and will create/delete test issues.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { E2ETestContext, runCLI } from './harness.ts';
+import { createIssue, getIssue, LinearClient } from '../../src/lib/api.ts';
+
+describe('issues done E2E', () => {
+  const ctx = new E2ETestContext();
+  let teams: { id: string; key: string; name: string }[];
+  let client: LinearClient;
+
+  beforeAll(async () => {
+    await ctx.setup();
+    ctx.requireApiKey();
+    teams = await ctx.getTeams();
+    client = await ctx.getLinearClient();
+
+    if (teams.length < 1) {
+      throw new Error('At least 1 team required for issues done E2E tests');
+    }
+  });
+
+  afterAll(async () => {
+    await ctx.teardown();
+  });
+
+  beforeEach(async () => {
+    await ctx.setup();
+  });
+
+  afterEach(async () => {
+    await ctx.teardown();
+  });
+
+  it('marks an issue as done', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    // Create a test issue
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Done command ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    const result = await runCLI(
+      ['issues', 'done', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✓');
+    expect(result.stdout).toContain(issue.identifier);
+
+    // Verify the issue state changed
+    const updated = await getIssue(client, issue.identifier);
+    expect(updated?.state.type).toBe('completed');
+  });
+
+  it('outputs JSON when --json flag is used', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Done JSON ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    const result = await runCLI(
+      ['issues', 'done', issue.identifier, '--json'],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.issue.identifier).toBe(issue.identifier);
+    expect(json.changes.state).toBeDefined();
+  });
+
+  it('handles already-done issues gracefully', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Already done ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    // Mark it done first
+    await runCLI(
+      ['issues', 'done', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    // Try to mark it done again
+    const result = await runCLI(
+      ['issues', 'done', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('already done');
+  });
+
+  it('fails for non-existent issue', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const result = await runCLI(
+      ['issues', 'done', 'NONEXISTENT-99999'],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not found');
+  });
+});

--- a/tests/e2e/issues-start.test.ts
+++ b/tests/e2e/issues-start.test.ts
@@ -1,0 +1,124 @@
+/**
+ * E2E tests for issues start command.
+ *
+ * Requires valid Linear authentication and will create/delete test issues.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'bun:test';
+import { E2ETestContext, runCLI } from './harness.ts';
+import { createIssue, getIssue, LinearClient } from '../../src/lib/api.ts';
+
+describe('issues start E2E', () => {
+  const ctx = new E2ETestContext();
+  let teams: { id: string; key: string; name: string }[];
+  let client: LinearClient;
+
+  beforeAll(async () => {
+    await ctx.setup();
+    ctx.requireApiKey();
+    teams = await ctx.getTeams();
+    client = await ctx.getLinearClient();
+
+    if (teams.length < 1) {
+      throw new Error('At least 1 team required for issues start E2E tests');
+    }
+  });
+
+  afterAll(async () => {
+    await ctx.teardown();
+  });
+
+  beforeEach(async () => {
+    await ctx.setup();
+  });
+
+  afterEach(async () => {
+    await ctx.teardown();
+  });
+
+  it('starts an issue', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    // Create a test issue
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Start command ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    const result = await runCLI(
+      ['issues', 'start', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✓');
+    expect(result.stdout).toContain(issue.identifier);
+
+    // Verify the issue state changed
+    const updated = await getIssue(client, issue.identifier);
+    expect(updated?.state.type).toBe('started');
+  });
+
+  it('outputs JSON when --json flag is used', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Start JSON ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    const result = await runCLI(
+      ['issues', 'start', issue.identifier, '--json'],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.success).toBe(true);
+    expect(json.issue.identifier).toBe(issue.identifier);
+    expect(json.changes.state).toBeDefined();
+  });
+
+  it('handles already-started issues gracefully', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const issue = await createIssue(client, {
+      teamId: testTeam.id,
+      title: `[TEST] Already started ${Date.now()}`,
+    });
+    ctx.trackCreatedIssue(issue.identifier);
+
+    // Start it first
+    await runCLI(
+      ['issues', 'start', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    // Try to start it again
+    const result = await runCLI(
+      ['issues', 'start', issue.identifier],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('already in progress');
+  });
+
+  it('fails for non-existent issue', async () => {
+    const testTeam = teams[0]!;
+    await ctx.setupV2Config({ defaultTeam: testTeam.key });
+
+    const result = await runCLI(
+      ['issues', 'start', 'NONEXISTENT-99999'],
+      { env: ctx.envWithoutApiKey() }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('not found');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `linproj issues done PROJ-123` to mark issues as completed
- Adds `linproj issues start PROJ-123` to mark issues as in progress
- Both resolve state by type (completed/started) so they work with custom team state names

## Test plan
- [x] E2E tests for both commands (8 tests total)
- [x] Typecheck passes
- [x] Manual verification via `--help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)