### PR TITLE
Fix flaky E2E tests with rate limiting and longer timeout

### DIFF
--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -2,7 +2,11 @@
  * Shared helpers for E2E tests.
  */
 
+import { setDefaultTimeout } from 'bun:test';
 import { join } from 'node:path';
+
+// E2E tests hit real APIs and can be slow - use 15 second timeout
+setDefaultTimeout(15_000);
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import {


### PR DESCRIPTION
## Summary

- Add rate limiter (100ms min delay) to LinearClient to avoid API throttling
- Increase E2E test timeout to 15 seconds via `setDefaultTimeout` in harness

## Test plan

- [x] E2E tests pass locally with rate limiter
- [x] Unit tests still pass

🤖 Generated with [Claude Code](https://claude.ai/code)