### PR TITLE
Fix flaky E2E tests with reduced concurrency and proper timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,15 @@ jobs:
       - uses: oven-sh/setup-bun@v2
       - run: bun install
       - run: bun run tsc --noEmit
-      - run: bun test
+      # Run unit and integration tests (fast, no API rate limit concerns)
+      - name: Run unit and integration tests
+        run: bun test tests/unit tests/integration
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+      # Run E2E tests with reduced concurrency to avoid API rate limits
+      # and retries for flaky network conditions
+      - name: Run E2E tests
+        run: bun test tests/e2e --preload ./tests/e2e/preload.ts --max-concurrency 5 --retry 2
         env:
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
 

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -1,12 +1,11 @@
 /**
  * Shared helpers for E2E tests.
+ *
+ * Note: Timeout is configured via tests/e2e/preload.ts which is loaded
+ * via `bun test --preload` to ensure it applies before tests register.
  */
 
-import { setDefaultTimeout } from 'bun:test';
 import { join } from 'node:path';
-
-// E2E tests hit real APIs and can be slow - use 15 second timeout
-setDefaultTimeout(15_000);
 import { mkdtemp, rm, mkdir, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import {

--- a/tests/e2e/preload.ts
+++ b/tests/e2e/preload.ts
@@ -1,0 +1,12 @@
+/**
+ * Preload file for E2E tests.
+ *
+ * This file is loaded before any test files via `bun test --preload`.
+ * It sets a longer timeout for E2E tests that hit real APIs.
+ */
+
+import { setDefaultTimeout } from 'bun:test';
+
+// E2E tests hit real APIs and can be slow - use 30 second timeout
+// (increased from 15s to account for CI variability)
+setDefaultTimeout(30_000);


### PR DESCRIPTION
## Summary
- Fix E2E test flakiness that was causing CI failures on main
- Root cause was two-fold: incorrect timeout (5s instead of 15s) and API rate limiting from concurrent tests

## Changes
- Add `tests/e2e/preload.ts` with 30s timeout, loaded via `--preload` flag
- Split CI into separate unit/integration and E2E test runs
- Run E2E tests with `--max-concurrency 5` to prevent Linear API flooding
- Add `--retry 2` for transient network failures

## Test plan
- [x] Ran E2E tests locally 3x with new configuration - all passed
- [x] Ran unit/integration tests separately - all passed
- [ ] CI should pass on this PR (the real test)

🤖 Generated with [Claude Code](https://claude.ai/code)