### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linproj",
-  "version": "0.1.0",
+  "version": "0.6.0",
   "description": "CLI for Linear",
   "module": "src/index.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { Command } from 'commander';
+import packageJson from '../package.json';
 import { createAuthCommand } from './commands/auth/index.ts';
 import { createIssuesCommand } from './commands/issues/index.ts';
 import { createWorkspaceCommand } from './commands/workspace/index.ts';
@@ -12,7 +13,7 @@ const program = new Command();
 program
   .name('linproj')
   .description('CLI for Linear')
-  .version('0.1.0');
+  .version(packageJson.version);
 
 program.addCommand(createAuthCommand());
 program.addCommand(createIssuesCommand());


### PR DESCRIPTION
## Summary
- Update package.json version from 0.1.0 to 0.6.0 to match the released version
- Fixes `linproj --version` showing incorrect version

## Test plan
- [ ] Build the binary locally with `bun run build`
- [ ] Run `./build/linproj --version` and confirm it shows `0.6.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)