### PR TITLE
Add teams list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `projects update list <project>` - List past status updates for a project, with `--limit` and `--json`
 - `projects update edit <update-id>` - Revise the body and/or health of an existing update, with stdin support
+- `teams list` - List the workspace's teams as a KEY / NAME table, with `--json`
 
 `projects update` is now a subcommand group. `projects update <project>` continues to
 create an update, so existing usage is unchanged.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@ A prioritized list of features for the linproj CLI.
 - `config get`, `config set`, `config unset`, `config migrate`
 - Default team configuration per workspace
 - `projects list`, `projects update` - List projects and post status updates
+- `teams list` - List the workspace's teams
 
 ---
 

--- a/src/commands/teams/index.ts
+++ b/src/commands/teams/index.ts
@@ -1,0 +1,10 @@
+import { Command } from 'commander';
+import { createListCommand } from './list.ts';
+
+export function createTeamsCommand(): Command {
+  const teams = new Command('teams').description('Team commands');
+
+  teams.addCommand(createListCommand());
+
+  return teams;
+}

--- a/src/commands/teams/list.ts
+++ b/src/commands/teams/list.ts
@@ -1,0 +1,47 @@
+import { Command } from 'commander';
+import { getAuthContext } from '../../lib/config.ts';
+import { LinearClient, getTeams } from '../../lib/api.ts';
+
+interface ListOptions {
+  json?: boolean;
+  workspace?: string;
+}
+
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
+}
+
+export function createListCommand(): Command {
+  return new Command('list')
+    .description('List all teams')
+    .option('--json', 'Output as JSON')
+    .option('-w, --workspace <name>', 'Use a different workspace')
+    .action(async (options: ListOptions) => {
+      let ctx;
+      try {
+        ctx = await getAuthContext(options.workspace);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      const client = new LinearClient(ctx.auth);
+      const teams = await getTeams(client);
+
+      if (options.json) {
+        console.log(JSON.stringify(teams, null, 2));
+        return;
+      }
+
+      if (teams.length === 0) {
+        console.log('No teams found.');
+        return;
+      }
+
+      const keyWidth = Math.max(3, ...teams.map((t) => t.key.length));
+      console.log(`${padRight('KEY', keyWidth)}  NAME`);
+      for (const team of teams) {
+        console.log(`${padRight(team.key, keyWidth)}  ${team.name}`);
+      }
+    });
+}

--- a/src/commands/teams/list.ts
+++ b/src/commands/teams/list.ts
@@ -1,14 +1,11 @@
 import { Command } from 'commander';
-import { getAuthContext } from '../../lib/config.ts';
+import { getAuthContextOrExit } from '../../lib/config.ts';
 import { LinearClient, getTeams } from '../../lib/api.ts';
+import { padRight } from '../../lib/output.ts';
 
 interface ListOptions {
   json?: boolean;
   workspace?: string;
-}
-
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
 }
 
 export function createListCommand(): Command {
@@ -17,31 +14,30 @@ export function createListCommand(): Command {
     .option('--json', 'Output as JSON')
     .option('-w, --workspace <name>', 'Use a different workspace')
     .action(async (options: ListOptions) => {
-      let ctx;
+      const ctx = await getAuthContextOrExit(options.workspace);
+      const client = new LinearClient(ctx.auth);
+
       try {
-        ctx = await getAuthContext(options.workspace);
+        const teams = await getTeams(client);
+
+        if (options.json) {
+          console.log(JSON.stringify(teams, null, 2));
+          return;
+        }
+
+        if (teams.length === 0) {
+          console.log('No teams found.');
+          return;
+        }
+
+        const keyWidth = Math.max(3, ...teams.map((team) => team.key.length));
+        console.log(`${padRight('KEY', keyWidth)}  NAME`);
+        for (const team of teams) {
+          console.log(`${padRight(team.key, keyWidth)}  ${team.name}`);
+        }
       } catch (err) {
         console.error(`Error: ${(err as Error).message}`);
         process.exit(1);
-      }
-
-      const client = new LinearClient(ctx.auth);
-      const teams = await getTeams(client);
-
-      if (options.json) {
-        console.log(JSON.stringify(teams, null, 2));
-        return;
-      }
-
-      if (teams.length === 0) {
-        console.log('No teams found.');
-        return;
-      }
-
-      const keyWidth = Math.max(3, ...teams.map((t) => t.key.length));
-      console.log(`${padRight('KEY', keyWidth)}  NAME`);
-      for (const team of teams) {
-        console.log(`${padRight(team.key, keyWidth)}  ${team.name}`);
       }
     });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { createWorkspaceCommand } from './commands/workspace/index.ts';
 import { createConfigCommand } from './commands/config/index.ts';
 import { createSkillCommand } from './commands/skill/index.ts';
 import { createProjectsCommand } from './commands/projects/index.ts';
+import { createTeamsCommand } from './commands/teams/index.ts';
 
 const program = new Command();
 
@@ -21,5 +22,6 @@ program.addCommand(createWorkspaceCommand());
 program.addCommand(createConfigCommand());
 program.addCommand(createSkillCommand());
 program.addCommand(createProjectsCommand());
+program.addCommand(createTeamsCommand());
 
 program.parse();


### PR DESCRIPTION
Adds `linproj teams list`, printing the workspace's teams as a KEY / NAME table
with `--json` and `--workspace` support. The `getTeams` API function already
existed, so this only wires up the command.

Team keys are the input other commands expect (`issues create --team ENG`,
`config set default-team`), and there was no way to discover them from the CLI.
This is read-only discovery, distinct from the "team management" non-goal in the
roadmap, which is about creating and administering teams.

Rebased onto main after #31, which exports `padRight` from `lib/output.ts`, so
this reuses that rather than carrying its own copy.

Closes #10

Slop Scale of this PR 3/5 ; of linproj 4/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
