### PR TITLE
Add project update list and edit commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `projects update list <project>` - List past status updates for a project, with `--limit` and `--json`
+- `projects update edit <update-id>` - Revise the body and/or health of an existing update, with stdin support
+
+`projects update` is now a subcommand group. `projects update <project>` continues to
+create an update, so existing usage is unchanged.
+
 ## [0.7.0] - 2026-02-19
 
 ### Added

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,6 +80,8 @@ Manage Linear projects and cycles.
 
 - [x] `linproj projects list`
 - [x] `linproj projects update <project>` - Post status updates with health status
+- [x] `linproj projects update list <project>` - List past status updates
+- [x] `linproj projects update edit <update-id>` - Edit an existing status update
 - [ ] `linproj projects get <name>`
 - [ ] `linproj cycles list`
 - [ ] `linproj cycles current`

--- a/src/commands/projects/update.ts
+++ b/src/commands/projects/update.ts
@@ -51,7 +51,7 @@ function parseHealth(value: string): ProjectHealth {
     console.error('Valid values: on-track, at-risk, off-track');
     process.exit(1);
   }
-  return HEALTH_MAP[healthLower];
+  return HEALTH_MAP[healthLower]!;
 }
 
 async function readStdin(): Promise<string> {
@@ -79,7 +79,7 @@ function truncateId(id: string): string {
 }
 
 function truncateBody(body: string, maxLen = 50): string {
-  const firstLine = body.split('\n')[0].trim();
+  const firstLine = (body.split('\n')[0] ?? '').trim();
   if (firstLine.length <= maxLen) return firstLine;
   return firstLine.slice(0, maxLen - 3) + '...';
 }

--- a/src/commands/projects/update.ts
+++ b/src/commands/projects/update.ts
@@ -9,6 +9,7 @@ import {
   type ProjectUpdate,
 } from '../../lib/api.ts';
 import { resolveProjectForUpdate } from '../../lib/resolve.ts';
+import { padRight } from '../../lib/output.ts';
 
 interface CreateOptions {
   body?: string;
@@ -66,10 +67,6 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8').trim();
 }
 
-function padRight(str: string, len: number): string {
-  return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
-}
-
 function formatDate(iso: string): string {
   return new Date(iso).toISOString().slice(0, 10);
 }
@@ -91,8 +88,11 @@ function printUpdatesTable(updates: ProjectUpdate[]): void {
   }
 
   const dateWidth = 10;
-  const healthWidth = Math.max(6, ...updates.map((u) => (HEALTH_DISPLAY[u.health] ?? u.health).length));
-  const authorWidth = Math.max(6, ...updates.map((u) => u.user.name.length));
+  const healthWidth = Math.max(
+    6,
+    ...updates.map((update) => (HEALTH_DISPLAY[update.health] ?? update.health).length)
+  );
+  const authorWidth = Math.max(6, ...updates.map((update) => update.user.name.length));
   const idWidth = 8;
 
   console.log(
@@ -188,14 +188,19 @@ function createListSubcommand(): Command {
         process.exit(1);
       }
 
-      const updates = await listProjectUpdates(client, projectId, limit);
+      try {
+        const updates = await listProjectUpdates(client, projectId, limit);
 
-      if (options.json) {
-        console.log(JSON.stringify(updates, null, 2));
-        return;
+        if (options.json) {
+          console.log(JSON.stringify(updates, null, 2));
+          return;
+        }
+
+        printUpdatesTable(updates);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
       }
-
-      printUpdatesTable(updates);
     });
 }
 
@@ -212,6 +217,11 @@ function createEditSubcommand(): Command {
       let health: ProjectHealth | undefined;
       if (options.health) {
         health = parseHealth(options.health);
+      }
+
+      if (options.body !== undefined && !options.body.trim()) {
+        console.error('Error: --body cannot be empty.');
+        process.exit(1);
       }
 
       let body = options.body;

--- a/src/commands/projects/update.ts
+++ b/src/commands/projects/update.ts
@@ -1,13 +1,30 @@
 import { Command } from 'commander';
-import { getAuthContext } from '../../lib/config.ts';
+import { getAuthContextOrExit } from '../../lib/config.ts';
 import {
   LinearClient,
   createProjectUpdate,
+  listProjectUpdates,
+  updateProjectUpdate,
   type ProjectHealth,
+  type ProjectUpdate,
 } from '../../lib/api.ts';
 import { resolveProjectForUpdate } from '../../lib/resolve.ts';
 
-interface UpdateOptions {
+interface CreateOptions {
+  body?: string;
+  health?: string;
+  json?: boolean;
+  quiet?: boolean;
+  workspace?: string;
+}
+
+interface ListOptions {
+  json?: boolean;
+  limit?: string;
+  workspace?: string;
+}
+
+interface EditOptions {
   body?: string;
   health?: string;
   json?: boolean;
@@ -21,9 +38,24 @@ const HEALTH_MAP: Record<string, ProjectHealth> = {
   'off-track': 'offTrack',
 };
 
+const HEALTH_DISPLAY: Record<string, string> = {
+  onTrack: 'On Track',
+  atRisk: 'At Risk',
+  offTrack: 'Off Track',
+};
+
+function parseHealth(value: string): ProjectHealth {
+  const healthLower = value.toLowerCase();
+  if (!(healthLower in HEALTH_MAP)) {
+    console.error(`Error: Invalid health status '${value}'.`);
+    console.error('Valid values: on-track, at-risk, off-track');
+    process.exit(1);
+  }
+  return HEALTH_MAP[healthLower];
+}
+
 async function readStdin(): Promise<string> {
-  const isTTY = process.stdin.isTTY;
-  if (isTTY) {
+  if (process.stdin.isTTY) {
     return '';
   }
 
@@ -34,8 +66,48 @@ async function readStdin(): Promise<string> {
   return Buffer.concat(chunks).toString('utf-8').trim();
 }
 
-export function createUpdateCommand(): Command {
-  return new Command('update')
+function padRight(str: string, len: number): string {
+  return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+function truncateId(id: string): string {
+  return id.slice(0, 8);
+}
+
+function truncateBody(body: string, maxLen = 50): string {
+  const firstLine = body.split('\n')[0].trim();
+  if (firstLine.length <= maxLen) return firstLine;
+  return firstLine.slice(0, maxLen - 3) + '...';
+}
+
+function printUpdatesTable(updates: ProjectUpdate[]): void {
+  if (updates.length === 0) {
+    console.log('No updates found');
+    return;
+  }
+
+  const dateWidth = 10;
+  const healthWidth = Math.max(6, ...updates.map((u) => (HEALTH_DISPLAY[u.health] ?? u.health).length));
+  const authorWidth = Math.max(6, ...updates.map((u) => u.user.name.length));
+  const idWidth = 8;
+
+  console.log(
+    `${padRight('DATE', dateWidth)}  ${padRight('HEALTH', healthWidth)}  ${padRight('AUTHOR', authorWidth)}  ${padRight('ID', idWidth)}  BODY`
+  );
+
+  for (const update of updates) {
+    console.log(
+      `${padRight(formatDate(update.createdAt), dateWidth)}  ${padRight(HEALTH_DISPLAY[update.health] ?? update.health, healthWidth)}  ${padRight(update.user.name, authorWidth)}  ${padRight(truncateId(update.id), idWidth)}  ${truncateBody(update.body)}`
+    );
+  }
+}
+
+function createCreateSubcommand(): Command {
+  return new Command('create')
     .description('Post a status update to a project')
     .argument('<project>', 'Project name or ID')
     .option('--body <text>', 'Update content (markdown supported)')
@@ -43,20 +115,12 @@ export function createUpdateCommand(): Command {
     .option('--json', 'Output as JSON')
     .option('--quiet', 'Suppress output on success')
     .option('-w, --workspace <name>', 'Use a different workspace')
-    .action(async (project: string, options: UpdateOptions) => {
-      // Validate health status early (before any API calls)
+    .action(async (project: string, options: CreateOptions) => {
       let health: ProjectHealth | undefined;
       if (options.health) {
-        const healthLower = options.health.toLowerCase();
-        if (!(healthLower in HEALTH_MAP)) {
-          console.error(`Error: Invalid health status '${options.health}'.`);
-          console.error('Valid values: on-track, at-risk, off-track');
-          process.exit(1);
-        }
-        health = HEALTH_MAP[healthLower];
+        health = parseHealth(options.health);
       }
 
-      // Get body from --body flag or stdin
       let body = options.body ?? '';
       if (!body) {
         body = await readStdin();
@@ -67,17 +131,9 @@ export function createUpdateCommand(): Command {
         process.exit(1);
       }
 
-      let ctx;
-      try {
-        ctx = await getAuthContext(options.workspace);
-      } catch (err) {
-        console.error(`Error: ${(err as Error).message}`);
-        process.exit(1);
-      }
-
+      const ctx = await getAuthContextOrExit(options.workspace);
       const client = new LinearClient(ctx.auth);
 
-      // Resolve project name to ID
       let projectId: string;
       try {
         projectId = await resolveProjectForUpdate(client, project);
@@ -93,9 +149,7 @@ export function createUpdateCommand(): Command {
           health,
         });
 
-        if (options.quiet) {
-          return;
-        }
+        if (options.quiet) return;
 
         if (options.json) {
           console.log(JSON.stringify(update, null, 2));
@@ -107,4 +161,102 @@ export function createUpdateCommand(): Command {
         process.exit(1);
       }
     });
+}
+
+function createListSubcommand(): Command {
+  return new Command('list')
+    .description('List status updates for a project')
+    .argument('<project>', 'Project name or ID')
+    .option('--json', 'Output as JSON')
+    .option('-n, --limit <n>', 'Maximum number of updates to show', '10')
+    .option('-w, --workspace <name>', 'Use a different workspace')
+    .action(async (project: string, options: ListOptions) => {
+      const limit = parseInt(options.limit ?? '10', 10);
+      if (isNaN(limit) || limit < 1) {
+        console.error('Error: Invalid limit value');
+        process.exit(1);
+      }
+
+      const ctx = await getAuthContextOrExit(options.workspace);
+      const client = new LinearClient(ctx.auth);
+
+      let projectId: string;
+      try {
+        projectId = await resolveProjectForUpdate(client, project);
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      const updates = await listProjectUpdates(client, projectId, limit);
+
+      if (options.json) {
+        console.log(JSON.stringify(updates, null, 2));
+        return;
+      }
+
+      printUpdatesTable(updates);
+    });
+}
+
+function createEditSubcommand(): Command {
+  return new Command('edit')
+    .description('Edit an existing project update')
+    .argument('<update-id>', 'Project update ID')
+    .option('--body <text>', 'New update content (markdown supported)')
+    .option('--health <status>', 'New health status: on-track, at-risk, off-track')
+    .option('--json', 'Output as JSON')
+    .option('--quiet', 'Suppress output on success')
+    .option('-w, --workspace <name>', 'Use a different workspace')
+    .action(async (updateId: string, options: EditOptions) => {
+      let health: ProjectHealth | undefined;
+      if (options.health) {
+        health = parseHealth(options.health);
+      }
+
+      let body = options.body;
+      if (body === undefined) {
+        const stdinBody = await readStdin();
+        if (stdinBody) {
+          body = stdinBody;
+        }
+      }
+
+      if (!body && !health) {
+        console.error('Error: At least one of --body or --health is required.');
+        process.exit(1);
+      }
+
+      const ctx = await getAuthContextOrExit(options.workspace);
+      const client = new LinearClient(ctx.auth);
+
+      try {
+        const update = await updateProjectUpdate(client, updateId, {
+          ...(body !== undefined && { body }),
+          ...(health !== undefined && { health }),
+        });
+
+        if (options.quiet) return;
+
+        if (options.json) {
+          console.log(JSON.stringify(update, null, 2));
+        } else {
+          console.log(`Project update edited: ${update.url}`);
+        }
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`);
+        process.exit(1);
+      }
+    });
+}
+
+export function createUpdateCommand(): Command {
+  const update = new Command('update')
+    .description('Manage project status updates');
+
+  update.addCommand(createCreateSubcommand(), { isDefault: true });
+  update.addCommand(createListSubcommand());
+  update.addCommand(createEditSubcommand());
+
+  return update;
 }

--- a/src/commands/skill/skills/linear/SKILL.md
+++ b/src/commands/skill/skills/linear/SKILL.md
@@ -136,6 +136,17 @@ linproj projects update "My Project" --health on-track --body "Sprint going well
 linproj projects update "My Project" --health at-risk --body "Blocked on API"
 ```
 
+Reviewing and revising past updates:
+```bash
+linproj projects update list "My Project"
+linproj projects update list "My Project" --limit 5 --json
+linproj projects update edit 87d76fd7 --body "Corrected update"
+linproj projects update edit 87d76fd7 --health at-risk
+```
+
+The ID column from `update list` is a short prefix of the update UUID. Both the
+prefix and the full UUID work as `<update-id>` for `update edit`.
+
 ### Project Health Values
 - `on-track` - Project is progressing as planned
 - `at-risk` - Project has potential blockers

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -588,6 +588,11 @@ export interface CreateProjectUpdateInput {
   health?: ProjectHealth;
 }
 
+export interface UpdateProjectUpdateInput {
+  body?: string;
+  health?: ProjectHealth;
+}
+
 export interface IssueUpdateInput {
   title?: string;
   description?: string;
@@ -860,6 +865,98 @@ export async function createProjectUpdate(
   }
 
   return result.projectUpdateCreate.projectUpdate;
+}
+
+interface ProjectUpdatesResponse {
+  project: {
+    projectUpdates: {
+      nodes: ProjectUpdate[];
+    };
+  } | null;
+}
+
+export async function listProjectUpdates(
+  client: LinearClient,
+  projectId: string,
+  first = 10
+): Promise<ProjectUpdate[]> {
+  const query = `
+    query($projectId: String!, $first: Int!) {
+      project(id: $projectId) {
+        projectUpdates(first: $first, orderBy: createdAt) {
+          nodes {
+            id
+            body
+            health
+            url
+            createdAt
+            project {
+              id
+              name
+            }
+            user {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+  `;
+  const result = await client.query<ProjectUpdatesResponse>(query, {
+    projectId,
+    first,
+  });
+  if (!result.project) {
+    throw new LinearAPIError('Project not found');
+  }
+  return result.project.projectUpdates.nodes;
+}
+
+interface UpdateProjectUpdateResponse {
+  projectUpdateUpdate: {
+    success: boolean;
+    projectUpdate: ProjectUpdate;
+  };
+}
+
+export async function updateProjectUpdate(
+  client: LinearClient,
+  id: string,
+  input: UpdateProjectUpdateInput
+): Promise<ProjectUpdate> {
+  const mutation = `
+    mutation($id: String!, $input: ProjectUpdateUpdateInput!) {
+      projectUpdateUpdate(id: $id, input: $input) {
+        success
+        projectUpdate {
+          id
+          body
+          health
+          url
+          createdAt
+          project {
+            id
+            name
+          }
+          user {
+            id
+            name
+          }
+        }
+      }
+    }
+  `;
+  const result = await client.query<UpdateProjectUpdateResponse>(mutation, {
+    id,
+    input,
+  });
+
+  if (!result.projectUpdateUpdate.success) {
+    throw new LinearAPIError('Failed to update project update');
+  }
+
+  return result.projectUpdateUpdate.projectUpdate;
 }
 
 // Comment operations

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -17,7 +17,7 @@ export function formatPriority(priority: number): string {
   }
 }
 
-function padRight(str: string, len: number): string {
+export function padRight(str: string, len: number): string {
   return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
 }
 


### PR DESCRIPTION
Restructures `projects update` into a subcommand group so past updates can be
listed and revised, not just created. `projects update <project>` still creates
an update (it is the default subcommand), so existing usage and the weekly-update
skill are unaffected.

`projects update list <project>` prints a DATE / HEALTH / AUTHOR / ID / BODY table
and supports `--limit` and `--json`. `projects update edit <update-id>` revises the
body and/or health of an existing update, reading the body from `--body` or stdin.

The ID column is an 8-character prefix of the update UUID rather than the full
value, to keep the table readable. Linear's `projectUpdate(id:)` resolves that
prefix, so the short ID can be pasted straight into `update edit`, which is the
workflow #26 asked for. Verified against the live API.

Caveat: the new subcommands have no test coverage yet. The existing e2e suite only
exercises `create`, and `list`/`edit` were verified manually against a real
workspace instead. Worth backfilling before the next release.

Closes #25, closes #26

Slop Scale of this PR 3/5 ; of linproj 4/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
