### PR TITLE
Accept Linear URLs anywhere an issue identifier is accepted

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -397,16 +397,29 @@ const ISSUE_FIELDS = `
     id
     identifier
   }
-  project {
+ project {
     id
     name
   }
 `;
 
+/**
+ * If input is a Linear URL (e.g. https://linear.app/team/issue/ENG-123/...),
+ * extract and return the issue identifier. Otherwise return the trimmed input.
+ */
+export function normalizeIssueIdentifier(input: string): string {
+  const trimmed = input.trim();
+  const match = trimmed.match(
+    /^(?:https?:\/\/)?(?:www\.)?linear\.app\/[^/]+\/issue\/([A-Za-z]+-\d+)/
+  );
+  return match ? match[1] : trimmed;
+}
+
 export async function getIssue(
   client: LinearClient,
   identifier: string
 ): Promise<Issue | null> {
+  identifier = normalizeIssueIdentifier(identifier);
   const query = `
     query($identifier: String!) {
       issue(id: $identifier) {
@@ -927,6 +940,7 @@ export async function getComments(
   issueId: string,
   first = 100
 ): Promise<{ issue: Issue; comments: Comment[] } | null> {
+  issueId = normalizeIssueIdentifier(issueId);
   const query = `
     query($issueId: String!, $first: Int!) {
       issue(id: $issueId) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -397,7 +397,7 @@ const ISSUE_FIELDS = `
     id
     identifier
   }
- project {
+  project {
     id
     name
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -412,7 +412,7 @@ export function normalizeIssueIdentifier(input: string): string {
   const match = trimmed.match(
     /^(?:https?:\/\/)?(?:www\.)?linear\.app\/[^/]+\/issue\/([A-Za-z]+-\d+)/
   );
-  return match ? match[1] : trimmed;
+  return match?.[1] ?? trimmed;
 }
 
 export async function getIssue(

--- a/tests/e2e/harness.ts
+++ b/tests/e2e/harness.ts
@@ -75,6 +75,7 @@ export async function runCLI(
 
   const proc = Bun.spawn(['bun', 'run', CLI_PATH, ...args], {
     env,
+    stdin: new Uint8Array(0),
     stdout: 'pipe',
     stderr: 'pipe',
   });

--- a/tests/unit/extract-identifier.test.ts
+++ b/tests/unit/extract-identifier.test.ts
@@ -1,0 +1,52 @@
+import { test, expect } from 'bun:test';
+import { normalizeIssueIdentifier } from '../../src/lib/api.ts';
+
+test('plain identifier passes through', () => {
+  expect(normalizeIssueIdentifier('ENG-123')).toBe('ENG-123');
+});
+
+test('plain identifier trims whitespace', () => {
+  expect(normalizeIssueIdentifier('  ENG-123  ')).toBe('ENG-123');
+});
+
+test('URL without slug', () => {
+  expect(normalizeIssueIdentifier('https://linear.app/acme/issue/ENG-123')).toBe('ENG-123');
+});
+
+test('URL with slug', () => {
+  expect(normalizeIssueIdentifier('https://linear.app/acme/issue/ENG-123/some-title')).toBe('ENG-123');
+});
+
+test('URL with query params', () => {
+  expect(normalizeIssueIdentifier('https://linear.app/acme/issue/ENG-123?foo=bar')).toBe('ENG-123');
+});
+
+test('UUID passthrough', () => {
+  expect(normalizeIssueIdentifier('c650d32a-125e-4cb7-83b4-b57cc2d457f2')).toBe(
+    'c650d32a-125e-4cb7-83b4-b57cc2d457f2'
+  );
+});
+
+test('HTTP URL (non-https)', () => {
+  expect(normalizeIssueIdentifier('http://linear.app/acme/issue/ENG-123/title')).toBe('ENG-123');
+});
+
+test('URL without protocol', () => {
+  expect(normalizeIssueIdentifier('linear.app/acme/issue/ENG-123/some-title')).toBe('ENG-123');
+});
+
+test('URL without protocol and no slug', () => {
+  expect(normalizeIssueIdentifier('linear.app/acme/issue/DOW-1')).toBe('DOW-1');
+});
+
+test('www URL', () => {
+  expect(normalizeIssueIdentifier('https://www.linear.app/acme/issue/ENG-123/title')).toBe('ENG-123');
+});
+
+test('www URL without protocol', () => {
+  expect(normalizeIssueIdentifier('www.linear.app/acme/issue/ENG-123/title')).toBe('ENG-123');
+});
+
+test('URL trims whitespace', () => {
+  expect(normalizeIssueIdentifier('  https://www.linear.app/acme/issue/ENG-123/title  ')).toBe('ENG-123');
+});


### PR DESCRIPTION
## Summary

- Add `normalizeIssueIdentifier()` to extract issue identifiers from Linear URLs, applied in `getIssue()` and `getComments()`
- Since all commands funnel through these functions, this single change point covers all commands: `get`, `start`, `done`, `edit`, `comments list`, `comments add`, and `create --parent`
- Handles URLs with/without protocol, www prefix, title slugs, query params, and whitespace

## Examples

```sh
# All of these now work identically:
linproj issues get ENG-123
linproj issues get https://linear.app/acme/issue/ENG-123
linproj issues get https://linear.app/acme/issue/ENG-123/some-title-slug
linproj issues get linear.app/acme/issue/ENG-123

# Works for all issue commands:
linproj issues start https://linear.app/acme/issue/ENG-123/fix-login-bug
linproj issues done https://linear.app/acme/issue/ENG-123/fix-login-bug
linproj issues comments list https://linear.app/acme/issue/ENG-123
linproj issues comments add https://linear.app/acme/issue/ENG-123 -b "looks good"
```

## Test plan
- [x] Unit tests for `normalizeIssueIdentifier()` (12 cases)
- [ ] Manual: `linproj issues get <linear-url>` returns same result as `linproj issues get <identifier>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)