### PR TITLE
refactor: export padRight from lib/output

### DIFF
--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -17,7 +17,7 @@ export function formatPriority(priority: number): string {
   }
 }
 
-function padRight(str: string, len: number): string {
+export function padRight(str: string, len: number): string {
   return str.length >= len ? str.slice(0, len) : str + ' '.repeat(len - str.length);
 }
 


### PR DESCRIPTION
## Summary
- Exports the existing `padRight` helper from `src/lib/output.ts` so it can be reused by other commands (teams list, project updates) instead of being duplicated.

## Test plan
- [x] `bun run build` passes
- [x] `bun test` passes (unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)