### PR TITLE
Select the e2e workspace by urlKey instead of a hardcoded UUID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,22 @@ test("hello world", () => {
 E2E tests run against the real Linear API using the `downstairs-dawgs` workspace. To run e2e tests:
 
 ```sh
-LINEAR_API_KEY=$(cat ~/.config/linproj/workspaces/c650d32a-125e-4cb7-83b4-b57cc2d457f2.json | jq -r '.auth.apiKey') bun test tests/e2e
+LINEAR_API_KEY=$(jq -r 'select(.urlKey == "downstairs-dawgs") | .auth.apiKey' ~/.config/linproj/workspaces/*.json)
+if [ -z "$LINEAR_API_KEY" ]; then
+  echo "downstairs-dawgs workspace not configured; run: linproj auth login"
+else
+  bun test tests/e2e
+fi
 ```
 
-The UUID `c650d32a-125e-4cb7-83b4-b57cc2d457f2` is the Linear workspace ID for `downstairs-dawgs`. This ensures tests run against the correct workspace.
+The workspace is selected by its `urlKey`, not by config filename. Each workspace
+is stored as `~/.config/linproj/workspaces/<organizationId>.json`, and that UUID
+differs per machine and changes whenever the workspace is re-authenticated, so
+hardcoding it goes stale and fails as a silent 401.
+
+Do not fall back to picking whichever workspace file happens to be first. The e2e
+suite creates issues, transitions them, and posts project updates, so pointing it
+at a real workspace writes test data into it. If the selector comes back empty,
+the fix is to authenticate against `downstairs-dawgs`, not to substitute another
+workspace.
 


### PR DESCRIPTION
The workspace UUID in CLAUDE.md does not exist in the local config directory, so
the documented e2e command substituted an empty API key and failed as a silent
401. The config filename is the organization id, which differs per machine and
changes whenever the workspace is re-authenticated, so hardcoding it was always
going to rot.

Selects the workspace by its `urlKey` instead, and warns rather than running when
it is absent.

The issue suggested globbing the directory and taking the first file. That is
worth avoiding: the e2e suite creates issues, transitions them, and posts project
updates, so silently falling back to whichever workspace happens to be first
writes test data into a real one. The snippet now says so explicitly.

Closes #39

Slop Scale of this PR 3/5 ; of linproj 4/5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
